### PR TITLE
fix: creating matrix with option weekStartOn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.1](https://github.com/its-danny/use-lilius/compare/v1.1.0...v1.1.1) (2021-03-26)
+
 ## [1.1.0](https://github.com/its-danny/use-lilius/compare/v1.0.0...v1.1.0) (2021-03-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-lilius",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A headless calendar hook for React.",
   "keywords": [
     "react",

--- a/src/use-lilius.ts
+++ b/src/use-lilius.ts
@@ -248,10 +248,13 @@ export const useLilius = ({
   const [calendar, setCalendar] = useState<Date[][]>([]);
 
   useEffect(() => {
-    const matrix = eachWeekOfInterval(
-      { start: startOfMonth(viewing), end: endOfMonth(viewing) },
-      { weekStartsOn },
-    ).map((week) => eachDayOfInterval({ start: startOfWeek(week), end: endOfWeek(week) }));
+    const matrix = eachWeekOfInterval({ start: startOfMonth(viewing), end: endOfMonth(viewing) }, { weekStartsOn }).map(
+      (week) =>
+        eachDayOfInterval({
+          start: startOfWeek(week, { weekStartsOn }),
+          end: endOfWeek(week, { weekStartsOn }),
+        }),
+    );
 
     setCalendar(matrix);
   }, [viewing]);


### PR DESCRIPTION
## Current behaviour
If you use hook useLilius and the option **weekStartsOn** is set to **Day.MONDAY**, it does not work properly. Calendar matrix still starts from SUNDAY.

## What have I changed
Option **weekStartsOn** is now passed to two functions from date-fns, which are used to build matrix: _startOfWeek_ and _endOfWeek_. After these changes matrix is built correct and it starts from the day you have passed to the option **weekStartsOn**.
