### PR TITLE
Perf: fix extraneous commits

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,8 @@ module.exports = {
 
     "prettier/prettier": "error",
 
+    "react-hooks/exhaustive-deps": 2,
+
     "simple-import-sort/imports": [
       "error",
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["airbnb-typescript", "plugin:prettier/recommended"],
+  extends: ["airbnb-typescript", "plugin:prettier/recommended", "plugin:react-hooks/recommended"],
 
   plugins: ["simple-import-sort", "prettier", "jest"],
 
@@ -36,7 +36,7 @@ module.exports = {
   },
 
   parserOptions: {
-    project: './tsconfig.eslint.json',
+    project: "./tsconfig.eslint.json",
   },
 
   env: {

--- a/examples/datepicker/multi-select.tsx
+++ b/examples/datepicker/multi-select.tsx
@@ -77,6 +77,7 @@ export const MultiSelect: React.FC = () => {
 
       setVisibleTagCount(newVisibleTagCount);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, previouslySelected]);
 
   return (

--- a/examples/datepicker/single-select.tsx
+++ b/examples/datepicker/single-select.tsx
@@ -123,6 +123,7 @@ export const SingleSelect: React.FC = () => {
   useEffect(() => {
     setInputValue(selected.length > 0 ? format(selected[0], "MM/dd/yyyy") : "");
     setViewing(selected.length > 0 ? selected[0] : new Date());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
 
   return (

--- a/src/use-lilius.ts
+++ b/src/use-lilius.ts
@@ -17,7 +17,7 @@ import {
   subMonths,
   subYears,
 } from "date-fns";
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 
 export enum Month {
   JANUARY,
@@ -245,19 +245,16 @@ export const useLilius = ({
     );
   };
 
-  const [calendar, setCalendar] = useState<Date[][]>([]);
-
-  useEffect(() => {
-    const matrix = eachWeekOfInterval({ start: startOfMonth(viewing), end: endOfMonth(viewing) }, { weekStartsOn }).map(
-      (week) =>
+  const calendar = useMemo<Date[][]>(
+    () =>
+      eachWeekOfInterval({ start: startOfMonth(viewing), end: endOfMonth(viewing) }, { weekStartsOn }).map((week) =>
         eachDayOfInterval({
           start: startOfWeek(week, { weekStartsOn }),
           end: endOfWeek(week, { weekStartsOn }),
         }),
-    );
-
-    setCalendar(matrix);
-  }, [viewing]);
+      ),
+    [viewing],
+  );
 
   return {
     clearTime,


### PR DESCRIPTION
Summary:

1. `calendar` is now directly derived from `viewing` thanks to `useMemo` instead of computed after effect. This spares on extraneous commit!
2. callbacks which are referentially stable (e.g., they don't depend on variables in `useLilius` scope) have been moved outside of `useLilius` (`inRange`, `clearTime`).
3. remaining callbacks have been wrapped in a `useCallback` hook to maintain referential equality and avoid potential extraneous re-renders in consumer components and hooks. [More on referential equality in this nice article](https://www.digitalocean.com/community/tutorials/react-usememo).
4. enable `react-hooks` eslint plugin which was installed but not used.
5. suppress rules of hooks infringements in `examples/`; you might want to take a look and fix those but I didn't want the scope of this PR to be too large. 