### PR TITLE
Add support for multiple months

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,4 +36,4 @@ use-lilius
 
 #### Defined in
 
-[use-lilius.ts:184](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L184)
+[use-lilius.ts:192](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L192)

--- a/docs/enums/Day.md
+++ b/docs/enums/Day.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[use-lilius.ts:43](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L43)
+[use-lilius.ts:44](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L44)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:39](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L39)
+[use-lilius.ts:40](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L40)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:44](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L44)
+[use-lilius.ts:45](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L45)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:38](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L38)
+[use-lilius.ts:39](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L39)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:42](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L42)
+[use-lilius.ts:43](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L43)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:40](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L40)
+[use-lilius.ts:41](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L41)
 
 ___
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:41](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L41)
+[use-lilius.ts:42](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L42)

--- a/docs/enums/Month.md
+++ b/docs/enums/Month.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[use-lilius.ts:26](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L26)
+[use-lilius.ts:27](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L27)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:30](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L30)
+[use-lilius.ts:31](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L31)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:34](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L34)
+[use-lilius.ts:35](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L35)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:24](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L24)
+[use-lilius.ts:25](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L25)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:23](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L23)
+[use-lilius.ts:24](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:29](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L29)
+[use-lilius.ts:30](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L30)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:28](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L28)
+[use-lilius.ts:29](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L29)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:25](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L25)
+[use-lilius.ts:26](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L26)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:27](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L27)
+[use-lilius.ts:28](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L28)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:33](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L33)
+[use-lilius.ts:34](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L34)
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:32](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L32)
+[use-lilius.ts:33](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L33)
 
 ___
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-[use-lilius.ts:31](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L31)
+[use-lilius.ts:32](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L32)

--- a/docs/interfaces/Options.md
+++ b/docs/interfaces/Options.md
@@ -6,11 +6,26 @@
 
 ### Properties
 
+- [numberOfMonths](Options.md#numberofmonths)
 - [selected](Options.md#selected)
 - [viewing](Options.md#viewing)
 - [weekStartsOn](Options.md#weekstartson)
 
 ## Properties
+
+### numberOfMonths
+
+• `Optional` **numberOfMonths**: `number`
+
+The number of month in calendar.
+
+**`default`** 1
+
+#### Defined in
+
+[use-lilius.ts:75](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L75)
+
+___
 
 ### selected
 
@@ -22,7 +37,7 @@ The initial date(s) selection.
 
 #### Defined in
 
-[use-lilius.ts:67](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L67)
+[use-lilius.ts:68](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L68)
 
 ___
 
@@ -36,7 +51,7 @@ The initial viewing date.
 
 #### Defined in
 
-[use-lilius.ts:60](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L60)
+[use-lilius.ts:61](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L61)
 
 ___
 
@@ -50,4 +65,4 @@ What day a week starts on within the calendar matrix.
 
 #### Defined in
 
-[use-lilius.ts:53](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L53)
+[use-lilius.ts:54](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L54)

--- a/docs/interfaces/Returns.md
+++ b/docs/interfaces/Returns.md
@@ -35,13 +35,13 @@
 
 ### calendar
 
-• **calendar**: `Date`[][]
+• **calendar**: `Date`[][][]
 
 A matrix of days based on the current viewing date.
 
 #### Defined in
 
-[use-lilius.ts:176](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L176)
+[use-lilius.ts:184](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L184)
 
 ___
 
@@ -53,7 +53,7 @@ The dates currently selected.
 
 #### Defined in
 
-[use-lilius.ts:131](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L131)
+[use-lilius.ts:139](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L139)
 
 ___
 
@@ -65,7 +65,7 @@ Override the currently selected dates.
 
 #### Defined in
 
-[use-lilius.ts:136](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L136)
+[use-lilius.ts:144](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L144)
 
 ___
 
@@ -78,7 +78,7 @@ the month and year are the only parts used.
 
 #### Defined in
 
-[use-lilius.ts:91](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L91)
+[use-lilius.ts:99](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L99)
 
 ___
 
@@ -91,7 +91,7 @@ the month and year are the only parts used.
 
 #### Defined in
 
-[use-lilius.ts:85](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L85)
+[use-lilius.ts:93](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L93)
 
 ## Methods
 
@@ -107,7 +107,7 @@ Reset the selected dates to [].
 
 #### Defined in
 
-[use-lilius.ts:141](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L141)
+[use-lilius.ts:149](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L149)
 
 ___
 
@@ -129,7 +129,7 @@ Returns a copy of the given date with the time set to 00:00:00:00.
 
 #### Defined in
 
-[use-lilius.ts:74](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L74)
+[use-lilius.ts:82](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L82)
 
 ___
 
@@ -151,7 +151,7 @@ Deselect one or more dates.
 
 #### Defined in
 
-[use-lilius.ts:156](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L156)
+[use-lilius.ts:164](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L164)
 
 ___
 
@@ -174,7 +174,7 @@ Deselect a range of dates (inclusive).
 
 #### Defined in
 
-[use-lilius.ts:171](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L171)
+[use-lilius.ts:179](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L179)
 
 ___
 
@@ -198,7 +198,7 @@ Returns whether or not a date is between 2 other dates (inclusive).
 
 #### Defined in
 
-[use-lilius.ts:79](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L79)
+[use-lilius.ts:87](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L87)
 
 ___
 
@@ -220,7 +220,7 @@ Determine whether or not a date has been selected.
 
 #### Defined in
 
-[use-lilius.ts:146](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L146)
+[use-lilius.ts:154](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L154)
 
 ___
 
@@ -243,7 +243,7 @@ Select one or more dates.
 
 #### Defined in
 
-[use-lilius.ts:151](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L151)
+[use-lilius.ts:159](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L159)
 
 ___
 
@@ -267,7 +267,7 @@ Select a range of dates (inclusive).
 
 #### Defined in
 
-[use-lilius.ts:166](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L166)
+[use-lilius.ts:174](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L174)
 
 ___
 
@@ -290,7 +290,7 @@ Toggle the selection of a date.
 
 #### Defined in
 
-[use-lilius.ts:161](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L161)
+[use-lilius.ts:169](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L169)
 
 ___
 
@@ -312,7 +312,7 @@ Set the viewing date to the given month.
 
 #### Defined in
 
-[use-lilius.ts:101](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L101)
+[use-lilius.ts:109](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L109)
 
 ___
 
@@ -328,7 +328,7 @@ Set the viewing date to the month after the current.
 
 #### Defined in
 
-[use-lilius.ts:111](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L111)
+[use-lilius.ts:119](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L119)
 
 ___
 
@@ -344,7 +344,7 @@ Set the viewing date to the year after the current.
 
 #### Defined in
 
-[use-lilius.ts:126](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L126)
+[use-lilius.ts:134](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L134)
 
 ___
 
@@ -360,7 +360,7 @@ Set the viewing date to the month before the current.
 
 #### Defined in
 
-[use-lilius.ts:106](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L106)
+[use-lilius.ts:114](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L114)
 
 ___
 
@@ -376,7 +376,7 @@ Set the viewing date to the year before the current.
 
 #### Defined in
 
-[use-lilius.ts:121](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L121)
+[use-lilius.ts:129](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L129)
 
 ___
 
@@ -392,7 +392,7 @@ Set the viewing date to today.
 
 #### Defined in
 
-[use-lilius.ts:96](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L96)
+[use-lilius.ts:104](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L104)
 
 ___
 
@@ -414,4 +414,4 @@ Set the viewing date to the given year.
 
 #### Defined in
 
-[use-lilius.ts:116](https://github.com/its-danny/use-lilius/blob/dd11a85/src/use-lilius.ts#L116)
+[use-lilius.ts:124](https://github.com/wappla/use-lilius/blob/6b366c7/src/use-lilius.ts#L124)

--- a/examples/datepicker/multi-select.tsx
+++ b/examples/datepicker/multi-select.tsx
@@ -168,29 +168,30 @@ export const MultiSelect: React.FC = () => {
             <Box sx={styles.calendarContainer}>
               <Box sx={styles.dayLabelContainer}>
                 {calendar.length > 0 &&
-                  calendar[0].map((day) => (
+                  calendar[0].weeks[0].map((day) => (
                     <Box key={`${day}`} sx={styles.dayLabel}>
                       {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
                     </Box>
                   ))}
               </Box>
 
-              {calendar.map((week) => (
-                <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
-                  {week.map((day) => (
-                    <Box
-                      data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
-                      data-selected={isSelected(day)}
-                      data-today={isToday(day)}
-                      key={`${day}`}
-                      onClick={() => toggle(day)}
-                      sx={styles.calendarMatrixDay}
-                    >
-                      <Text>{format(day, "dd")}</Text>
-                    </Box>
-                  ))}
-                </Box>
-              ))}
+              {calendar.length > 0 &&
+                calendar[0].weeks.map((week) => (
+                  <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
+                    {week.map((day) => (
+                      <Box
+                        data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
+                        data-selected={isSelected(day)}
+                        data-today={isToday(day)}
+                        key={`${day}`}
+                        onClick={() => toggle(day)}
+                        sx={styles.calendarMatrixDay}
+                      >
+                        <Text>{format(day, "dd")}</Text>
+                      </Box>
+                    ))}
+                  </Box>
+                ))}
             </Box>
 
             <Divider sx={styles.divider} />

--- a/examples/datepicker/multi-select.tsx
+++ b/examples/datepicker/multi-select.tsx
@@ -78,7 +78,7 @@ export const MultiSelect: React.FC = () => {
       setVisibleTagCount(newVisibleTagCount);
     }
   }, [selected, previouslySelected, visibleTagCount]);
-
+  const [month] = calendar;
   return (
     <Box width={500}>
       <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
@@ -167,16 +167,16 @@ export const MultiSelect: React.FC = () => {
 
             <Box sx={styles.calendarContainer}>
               <Box sx={styles.dayLabelContainer}>
-                {calendar.length > 0 &&
-                  calendar[0].weeks[0].map((day) => (
+                {month.length > 0 &&
+                  month.map((day) => (
                     <Box key={`${day}`} sx={styles.dayLabel}>
                       {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
                     </Box>
                   ))}
               </Box>
 
-              {calendar.length > 0 &&
-                calendar[0].weeks.map((week) => (
+              {month.length > 0 &&
+                month.map((week) => (
                   <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
                     {week.map((day) => (
                       <Box

--- a/examples/datepicker/range-select.tsx
+++ b/examples/datepicker/range-select.tsx
@@ -49,7 +49,6 @@ export const RangeSelect: React.FC = () => {
   const styles = useMultiStyleConfig("Datepicker", {});
 
   const [isOpen, setIsOpen] = useState(false);
-
   return (
     <Box width={300}>
       <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
@@ -128,9 +127,9 @@ export const RangeSelect: React.FC = () => {
                 sx={styles.navigationButton}
               />
 
-              {calendar.map((month) => (
-                <Text key={month.firstDay.toDateString()} sx={styles.navigationLabel}>
-                  {format(month.firstDay, "MMMM yyyy")}
+              {calendar.map(([[firstDay]]) => (
+                <Text key={firstDay.toDateString()} sx={styles.navigationLabel}>
+                  {format(firstDay, "MMMM yyyy")}
                 </Text>
               ))}
 
@@ -145,20 +144,20 @@ export const RangeSelect: React.FC = () => {
 
             <Stack direction="row">
               {calendar.map((month) => (
-                <Box w="50%" key={month.firstDay.toDateString()}>
+                <Box w="50%" key={month[0][0].toDateString()}>
                   <Box sx={styles.calendarContainer}>
                     <Box sx={styles.dayLabelContainer}>
-                      {month.weeks.length > 0 &&
-                        month.weeks[0].map((day) => (
+                      {month.length > 0 &&
+                        month.map((day) => (
                           <Box key={`${day}`} sx={styles.dayLabel}>
                             {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
                           </Box>
                         ))}
                     </Box>
 
-                    {month.weeks.map((week) => (
+                    {month.map((week) => (
                       <Box
-                        key={`month-${month.firstDay.toDateString()}-week-${week[0]}`}
+                        key={`month-${month[0][0].toDateString()}-week-${week[0]}`}
                         sx={styles.calendarMatrixContainer}
                       >
                         {week.map((day) => (

--- a/examples/datepicker/range-select.tsx
+++ b/examples/datepicker/range-select.tsx
@@ -9,6 +9,7 @@ import {
   PopoverBody,
   PopoverContent,
   PopoverTrigger,
+  Stack,
   Text,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
@@ -43,7 +44,7 @@ export const RangeSelect: React.FC = () => {
     viewNextMonth,
     viewPreviousMonth,
     viewToday,
-  } = useLilius();
+  } = useLilius({ numberOfMonths: 2 });
 
   const styles = useMultiStyleConfig("Datepicker", {});
 
@@ -94,7 +95,7 @@ export const RangeSelect: React.FC = () => {
           </Box>
         </PopoverTrigger>
 
-        <PopoverContent sx={styles.popContent}>
+        <PopoverContent sx={styles.popContent} w="600px">
           <PopoverBody sx={styles.popBody}>
             <ButtonGroup sx={styles.shortcutButtonGroup}>
               <Button
@@ -127,7 +128,11 @@ export const RangeSelect: React.FC = () => {
                 sx={styles.navigationButton}
               />
 
-              <Text sx={styles.navigationLabel}>{format(viewing, "MMMM yyyy")}</Text>
+              {calendar.map((month) => (
+                <Text key={month.firstDay.toDateString()} sx={styles.navigationLabel}>
+                  {format(month.firstDay, "MMMM yyyy")}
+                </Text>
+              ))}
 
               <IconButton
                 aria-label="Next Month"
@@ -138,55 +143,68 @@ export const RangeSelect: React.FC = () => {
               />
             </Box>
 
-            <Box sx={styles.calendarContainer}>
-              <Box sx={styles.dayLabelContainer}>
-                {calendar.length > 0 &&
-                  calendar[0].map((day) => (
-                    <Box key={`${day}`} sx={styles.dayLabel}>
-                      {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
+            <Stack direction="row">
+              {calendar.map((month) => (
+                <Box w="50%" key={month.firstDay.toDateString()}>
+                  <Box sx={styles.calendarContainer}>
+                    <Box sx={styles.dayLabelContainer}>
+                      {month.weeks.length > 0 &&
+                        month.weeks[0].map((day) => (
+                          <Box key={`${day}`} sx={styles.dayLabel}>
+                            {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
+                          </Box>
+                        ))}
                     </Box>
-                  ))}
-              </Box>
 
-              {calendar.map((week) => (
-                <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
-                  {week.map((day) => (
-                    <Box
-                      data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
-                      data-selected={isSelected(day)}
-                      data-today={isToday(day)}
-                      data-dont-round={
-                        isSelected(day) && !isEqual(day, selected[0]) && !isEqual(day, selected[selected.length - 1])
-                      }
-                      data-dont-round-left={isSelected(day) && !isEqual(day, selected[0])}
-                      data-dont-round-right={isSelected(day) && !isEqual(day, selected[selected.length - 1])}
-                      key={`${day}`}
-                      onClick={() => {
-                        const sorted = selected.sort((a, b) => compareAsc(a, b));
+                    {month.weeks.map((week) => (
+                      <Box
+                        key={`month-${month.firstDay.toDateString()}-week-${week[0]}`}
+                        sx={styles.calendarMatrixContainer}
+                      >
+                        {week.map((day) => (
+                          <Box
+                            data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
+                            data-selected={isSelected(day)}
+                            data-today={isToday(day)}
+                            data-dont-round={
+                              isSelected(day) &&
+                              !isEqual(day, selected[0]) &&
+                              !isEqual(day, selected[selected.length - 1])
+                            }
+                            data-dont-round-left={isSelected(day) && !isEqual(day, selected[0])}
+                            data-dont-round-right={isSelected(day) && !isEqual(day, selected[selected.length - 1])}
+                            key={`${day}`}
+                            onClick={() => {
+                              const sorted = selected.sort((a, b) => compareAsc(a, b));
 
-                        if (sorted.length === 0) {
-                          select(day);
-                        } else if (isSelected(day)) {
-                          if (selected.length === 1) {
-                            deselect(day);
-                          } else {
-                            const range = eachDayOfInterval({ start: sorted[0], end: day });
-                            const diff = sorted.filter((d) => range.map((a) => a.getTime()).includes(d.getTime()));
+                              if (sorted.length === 0) {
+                                select(day);
+                              } else if (isSelected(day)) {
+                                if (selected.length === 1) {
+                                  deselect(day);
+                                } else {
+                                  const range = eachDayOfInterval({ start: sorted[0], end: day });
+                                  const diff = sorted.filter((d) =>
+                                    range.map((a) => a.getTime()).includes(d.getTime()),
+                                  );
 
-                            selectRange(diff[0], diff[diff.length - 1], true);
-                          }
-                        } else {
-                          selectRange(sorted[0], day, true);
-                        }
-                      }}
-                      sx={styles.calendarMatrixDay}
-                    >
-                      <Text>{format(day, "dd")}</Text>
-                    </Box>
-                  ))}
+                                  selectRange(diff[0], diff[diff.length - 1], true);
+                                }
+                              } else {
+                                selectRange(sorted[0], day, true);
+                              }
+                            }}
+                            sx={styles.calendarMatrixDay}
+                          >
+                            <Text>{format(day, "dd")}</Text>
+                          </Box>
+                        ))}
+                      </Box>
+                    ))}
+                  </Box>
                 </Box>
               ))}
-            </Box>
+            </Stack>
 
             <Divider sx={styles.divider} />
 

--- a/examples/datepicker/single-select.tsx
+++ b/examples/datepicker/single-select.tsx
@@ -202,29 +202,30 @@ export const SingleSelect: React.FC = () => {
             <Box sx={styles.calendarContainer}>
               <Box sx={styles.dayLabelContainer}>
                 {calendar.length > 0 &&
-                  calendar[0].map((day) => (
+                  calendar[0].weeks[0].map((day) => (
                     <Box key={`${day}`} sx={styles.dayLabel}>
                       {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
                     </Box>
                   ))}
               </Box>
 
-              {calendar.map((week) => (
-                <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
-                  {week.map((day) => (
-                    <Box
-                      data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
-                      data-selected={isSelected(day)}
-                      data-today={isToday(day)}
-                      key={`${day}`}
-                      onClick={() => toggle(day, true)}
-                      sx={styles.calendarMatrixDay}
-                    >
-                      <Text>{format(day, "dd")}</Text>
-                    </Box>
-                  ))}
-                </Box>
-              ))}
+              {calendar.length > 0 &&
+                calendar[0].weeks.map((week) => (
+                  <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
+                    {week.map((day) => (
+                      <Box
+                        data-in-range={inRange(day, startOfMonth(viewing), endOfMonth(viewing))}
+                        data-selected={isSelected(day)}
+                        data-today={isToday(day)}
+                        key={`${day}`}
+                        onClick={() => toggle(day, true)}
+                        sx={styles.calendarMatrixDay}
+                      >
+                        <Text>{format(day, "dd")}</Text>
+                      </Box>
+                    ))}
+                  </Box>
+                ))}
             </Box>
 
             <Divider sx={styles.divider} />

--- a/examples/datepicker/single-select.tsx
+++ b/examples/datepicker/single-select.tsx
@@ -202,7 +202,7 @@ export const SingleSelect: React.FC = () => {
             <Box sx={styles.calendarContainer}>
               <Box sx={styles.dayLabelContainer}>
                 {calendar.length > 0 &&
-                  calendar[0].weeks[0].map((day) => (
+                  calendar[0][0].map((day) => (
                     <Box key={`${day}`} sx={styles.dayLabel}>
                       {["Sun", "Mon", "Tue", "Wed", "Tue", "Thu", "Fri", "Sat"][getDay(day)]}
                     </Box>
@@ -210,7 +210,7 @@ export const SingleSelect: React.FC = () => {
               </Box>
 
               {calendar.length > 0 &&
-                calendar[0].weeks.map((week) => (
+                calendar[0].map((week) => (
                   <Box key={`week-${week[0]}`} sx={styles.calendarMatrixContainer}>
                     {week.map((day) => (
                       <Box

--- a/src/use-lilius.tests.tsx
+++ b/src/use-lilius.tests.tsx
@@ -313,8 +313,18 @@ describe("calendar", () => {
   it("returns a matrix of days based on the current viewing date", () => {
     const { result } = renderHook(() => useLilius({ viewing: new Date(1582, Month.OCTOBER, 1) }));
 
-    expect(result.current.calendar![0][0]).toStrictEqual(new Date(1582, Month.SEPTEMBER, 26));
-    expect(result.current.calendar![0][5]).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
-    expect(result.current.calendar![5][6]).toStrictEqual(new Date(1582, Month.NOVEMBER, 6));
+    expect(result.current.calendar![0].firstDay).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
+    expect(result.current.calendar![0].weeks[0][0]).toStrictEqual(new Date(1582, Month.SEPTEMBER, 26));
+    expect(result.current.calendar![0].weeks[0][5]).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
+    expect(result.current.calendar![0].weeks[5][6]).toStrictEqual(new Date(1582, Month.NOVEMBER, 6));
+  });
+});
+
+describe("calendar two months", () => {
+  it("returns a matrix of days based on the current viewing date for two months", () => {
+    const { result } = renderHook(() => useLilius({ viewing: new Date(1582, Month.OCTOBER, 1), numberOfMonths: 2 }));
+
+    expect(result.current.calendar![0].firstDay).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
+    expect(result.current.calendar![1].firstDay).toStrictEqual(new Date(1582, Month.NOVEMBER, 1));
   });
 });

--- a/src/use-lilius.tests.tsx
+++ b/src/use-lilius.tests.tsx
@@ -313,10 +313,9 @@ describe("calendar", () => {
   it("returns a matrix of days based on the current viewing date", () => {
     const { result } = renderHook(() => useLilius({ viewing: new Date(1582, Month.OCTOBER, 1) }));
 
-    expect(result.current.calendar![0].firstDay).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
-    expect(result.current.calendar![0].weeks[0][0]).toStrictEqual(new Date(1582, Month.SEPTEMBER, 26));
-    expect(result.current.calendar![0].weeks[0][5]).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
-    expect(result.current.calendar![0].weeks[5][6]).toStrictEqual(new Date(1582, Month.NOVEMBER, 6));
+    expect(result.current.calendar![0][0][0]).toStrictEqual(new Date(1582, Month.SEPTEMBER, 26));
+    expect(result.current.calendar![0][0][5]).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
+    expect(result.current.calendar![0][5][6]).toStrictEqual(new Date(1582, Month.NOVEMBER, 6));
   });
 });
 
@@ -324,7 +323,7 @@ describe("calendar two months", () => {
   it("returns a matrix of days based on the current viewing date for two months", () => {
     const { result } = renderHook(() => useLilius({ viewing: new Date(1582, Month.OCTOBER, 1), numberOfMonths: 2 }));
 
-    expect(result.current.calendar![0].firstDay).toStrictEqual(new Date(1582, Month.OCTOBER, 1));
-    expect(result.current.calendar![1].firstDay).toStrictEqual(new Date(1582, Month.NOVEMBER, 1));
+    expect(result.current.calendar![0][0][0]).toStrictEqual(new Date(1582, Month.SEPTEMBER, 26));
+    expect(result.current.calendar![1][0][0]).toStrictEqual(new Date(1582, Month.OCTOBER, 31));
   });
 });

--- a/src/use-lilius.ts
+++ b/src/use-lilius.ts
@@ -75,11 +75,6 @@ export interface Options {
   numberOfMonths?: number;
 }
 
-export interface CalendarMonth {
-  firstDay: Date;
-  weeks: Date[][];
-}
-
 export interface Returns {
   /**
    * Returns a copy of the given date with the time set to 00:00:00:00.
@@ -186,7 +181,7 @@ export interface Returns {
   /**
    * A matrix of days based on the current viewing date.
    */
-  calendar: CalendarMonth[];
+  calendar: Date[][][];
 }
 
 const inRange = (date: Date, min: Date, max: Date) =>
@@ -264,18 +259,27 @@ export const useLilius = ({
     );
   }, []);
 
-  const calendar = useMemo<Date[][]>(
+  const calendar = useMemo<Date[][][]>(
     () =>
-      eachWeekOfInterval({ start: startOfMonth(viewing), end: endOfMonth(viewing) }, { weekStartsOn }).map((week) =>
-        eachDayOfInterval({
-          start: startOfWeek(week, { weekStartsOn }),
-          end: endOfWeek(week, { weekStartsOn }),
-        }),
+      eachMonthOfInterval({
+        start: startOfMonth(viewing),
+        end: endOfMonth(addMonths(viewing, numberOfMonths - 1)),
+      }).map((month) =>
+        eachWeekOfInterval(
+          {
+            start: startOfMonth(month),
+            end: endOfMonth(month),
+          },
+          { weekStartsOn },
+        ).map((week) =>
+          eachDayOfInterval({
+            start: startOfWeek(week, { weekStartsOn }),
+            end: endOfWeek(week, { weekStartsOn }),
+          }),
+        ),
       ),
-    [viewing, weekStartsOn],
+    [viewing, weekStartsOn, numberOfMonths],
   );
-
-
   return {
     clearTime,
     inRange,

--- a/src/use-lilius.ts
+++ b/src/use-lilius.ts
@@ -2,6 +2,7 @@ import {
   addMonths,
   addYears,
   eachDayOfInterval,
+  eachMonthOfInterval,
   eachWeekOfInterval,
   endOfMonth,
   endOfWeek,
@@ -65,6 +66,18 @@ export interface Options {
    * @default []
    */
   selected?: Date[];
+
+  /**
+   * The number of month in calendar.
+   *
+   * @default 1
+   */
+  numberOfMonths?: number;
+}
+
+export interface CalendarMonth {
+  firstDay: Date;
+  weeks: Date[][];
 }
 
 export interface Returns {
@@ -173,7 +186,7 @@ export interface Returns {
   /**
    * A matrix of days based on the current viewing date.
    */
-  calendar: Date[][];
+  calendar: CalendarMonth[];
 }
 
 const inRange = (date: Date, min: Date, max: Date) =>
@@ -185,6 +198,7 @@ export const useLilius = ({
   weekStartsOn = Day.SUNDAY,
   viewing: initialViewing = new Date(),
   selected: initialSelected = [],
+  numberOfMonths = 1,
 }: Options = {}): Returns => {
   const [viewing, setViewing] = useState<Date>(initialViewing);
 
@@ -260,6 +274,7 @@ export const useLilius = ({
       ),
     [viewing, weekStartsOn],
   );
+
 
   return {
     clearTime,


### PR DESCRIPTION
This PR builds on the work of @vf1. His PR seems to be abandoned because he needed a more specific implementation. I liked the idea of keeping things simple and just adding another dimension to the calendar array. This is however a breaking change and might warent a v2 release. 

The calendar now returns `Date[][][]` instead of `Date[][]`. The first dimension represents the months, the second represents the weeks in the month and the third the days inside the week. 



